### PR TITLE
delete now removes items from join table

### DIFF
--- a/src/javascripts/components/cards/ingredientsCard.js
+++ b/src/javascripts/components/cards/ingredientsCard.js
@@ -1,4 +1,7 @@
+// import Axios from 'axios';
 import ingredientData from '../../helpers/data/ingredientsData';
+import menuItemIngredientData from '../../helpers/data/menuItemIngredientsData';
+import menuItemsData from '../../helpers/data/menuItemsData';
 
 const ingredientMaker = (object) => {
   const domString = `<div class="ingredient-card card" style="width: 23rem;" id="${object.uid}">
@@ -15,7 +18,18 @@ const ingredientMaker = (object) => {
     e.stopImmediatePropagation();
     const firebaseKey = e.currentTarget.id;
     $(`.ingredient-card#${firebaseKey}`).remove();
-    ingredientData.deleteIngredient(firebaseKey);
+    menuItemsData.getMenuItems().then((response) => {
+      response.forEach((item) => {
+        menuItemIngredientData.getIngredientObjs(item.id).then((res) => {
+          res.forEach((menuId) => {
+            if (menuId.ingredientId === firebaseKey) {
+              ingredientData.deleteIngredient(firebaseKey);
+              menuItemIngredientData.deleteMenuIngredients(menuId.fbKey);
+            }
+          });
+        });
+      });
+    });
   });
 
   return domString;

--- a/src/javascripts/components/cards/menuItemsCard.js
+++ b/src/javascripts/components/cards/menuItemsCard.js
@@ -40,7 +40,18 @@ const authMenuItemCardMaker = (item) => {
     e.stopImmediatePropagation();
     const firebaseKey = e.currentTarget.id;
     $(`.card-menu#${firebaseKey}`).remove();
-    menuData.deleteMenuItem(firebaseKey);
+    menuData.getMenuItems().then((response) => {
+      response.forEach((menuItem) => {
+        menuItemIngredientsData.getIngredientObjs(menuItem.id).then((res) => {
+          res.forEach((menuId) => {
+            if (menuId.menuItemId === firebaseKey) {
+              menuData.deleteMenuItem(firebaseKey);
+              menuItemIngredientsData.deleteMenuIngredients(menuId.fbKey);
+            }
+          });
+        });
+      });
+    });
   });
   menuItemIngredientsData
     .getMenuItemIngredients(item.id)


### PR DESCRIPTION
## Description
When the user deletes a menu item or ingredient, it now deletes it from the join table.

## Related Issue
#100 

## Motivation and Context
When you deleted a menu item or ingredient, it would not delete from the join table. Now it does.

## How Can This Be Tested?
git fetch origin deleteJoinTable


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)