### PR TITLE
fixed duplication bug after adding order

### DIFF
--- a/src/javascripts/components/views/addOrdersView.js
+++ b/src/javascripts/components/views/addOrdersView.js
@@ -104,9 +104,9 @@ const addOrdersView = (reservationId) => {
         };
         menuIngredients.subtractQuantity(menuItem.id);
         orderReservation.addOrderReservation(data);
-        orderData.clearOrder(reservId);
-        reservationView.reservationView();
       });
+      orderData.clearOrder(reservId);
+      reservationView.reservationView();
     }
   });
 };


### PR DESCRIPTION
## Description
Fixed bug that would cause reservations to duplicate after adding an order with multiple menu items.

## Related Issue

## Motivation and Context
Keeps reservations from duplicating

## How Can This Be Tested?
`git fetch origin order-bug-fix`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)